### PR TITLE
fix: update repository URLs to use lowercase and bump version to 8.6.10

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,5 +17,5 @@ Click the "Fork" button in the upper right corner of the repository to create yo
 Clone your forked repository to your local machine:
 
 ```bash
-git clone https://github.com/Nexoral/outers.git
+git clone https://github.com/nexoral/outers.git
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## outers - a all in one package for your day to day use
 
 [![npm version](https://badge.fury.io/js/outers.svg)](https://badge.fury.io/js/outers)
-[![CodeQL](https://github.com/Nexoral/outers/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/Nexoral/outers/actions/workflows/github-code-scanning/codeql)
+[![CodeQL](https://github.com/nexoral/outers/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/nexoral/outers/actions/workflows/github-code-scanning/codeql)
 
 This package provides services like Response Sender, Colorful Console, HTTP Status Codes, API Call, Random Number Generate, Create Cluster in NodeJS Easily also you can Store Temporary Data in Server Side like localStorage in Client Side
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "outers",
-  "version": "8.6.9",
+  "version": "8.6.10",
   "description": "outers - a all in one package for your day to day use",
   "main": "./lib/Config/outer.js",
   "types": "./lib/Config/outer.d.ts",
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/Nexoral/outers.git"
+    "url": "git://github.com/nexoral/outers.git"
   },
   "keywords": [
     "outer",


### PR DESCRIPTION
This pull request updates repository references to use the correct lowercase GitHub username and bumps the package version. The changes ensure consistency and proper linking throughout the documentation and configuration.

Repository reference updates:

* Updated all GitHub repository URLs in `README.md`, `CONTRIBUTING.md`, and `package.json` to use `nexoral` instead of `Nexoral` for consistency and to avoid broken links. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R4) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L20-R20) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L14-R14)

Version update:

* Incremented the package version from `8.6.9` to `8.6.10` in `package.json` to reflect the latest changes.